### PR TITLE
fix: Grid size option was not changeable

### DIFF
--- a/src/maps/components/app.tsx
+++ b/src/maps/components/app.tsx
@@ -18,7 +18,7 @@ function App() {
         draft.gridSize = dataSet.info.gridSize
       })
     }
-  }, [dataSet, optionsValue])
+  }, [dataSet])
 
   const handleClearDataSet = () => setGlobalState(getDefaultState())
 


### PR DESCRIPTION
On each change the grid size was being reset to the dataset default